### PR TITLE
Ignore formatting codes when calculting the maximum line length.

### DIFF
--- a/src/main/java/dev/mylesmor/sudosigns/listeners/ChatListener.java
+++ b/src/main/java/dev/mylesmor/sudosigns/listeners/ChatListener.java
@@ -135,7 +135,7 @@ public class ChatListener implements Listener {
                             handle(e, true, "Cancelled!", editor, user, null, editor::goToMessages);
                             return;
                         }
-                        if (e.getMessage().length() > 15) {
+                        if (e.getMessage().replaceAll("&([0-9]|[a-g]|[k-o]|r)", "").length() > 15) {
                             e.setCancelled(true);
                             Util.sudoSignsMessage(p, ChatColor.RED, "The message can't be greater than 15 characters!", "");
                             return;


### PR DESCRIPTION
This avoids being blocked from setting a message that is acceptable [length-wise] but had formatting codes chucked in. You can test with a message such as `Click here for` which would surpass 15 characters if you add a `&l` to the front of it.